### PR TITLE
Fragment comparison use startchar & endchar, instead of PyObject id

### DIFF
--- a/src/whoosh/highlight.py
+++ b/src/whoosh/highlight.py
@@ -152,10 +152,7 @@ class Fragment(object):
         return max(ec, fec) - min(sc, fsc)
 
     def __lt__(self, other):
-        if self.startchar != other.startchar:
-            return self.startchar < other.startchar
-        else:
-            return self.endchar < other.endchar
+        return self.startchar < other.startchar
 
 
 # Tokenizing

--- a/src/whoosh/highlight.py
+++ b/src/whoosh/highlight.py
@@ -152,7 +152,10 @@ class Fragment(object):
         return max(ec, fec) - min(sc, fsc)
 
     def __lt__(self, other):
-        return id(self) < id(other)
+        if self.startchar != other.startchar:
+            return self.startchar < other.startchar
+        else:
+            return self.endchar < other.endchar
 
 
 # Tokenizing


### PR DESCRIPTION
for https://github.com/whoosh-community/whoosh/issues/491
