### PR TITLE
Resolve Bug #461

### DIFF
--- a/src/whoosh/matching/binary.py
+++ b/src/whoosh/matching/binary.py
@@ -286,7 +286,7 @@ class UnionMatcher(AdditiveBiMatcher):
         skipped = 0
         aq = a.block_quality()
         bq = b.block_quality()
-        while a.is_active() and b.is_active() and aq + bq <= minquality:
+        while a.is_active() and b.is_active() and aq + bq < minquality:
             if aq < bq:
                 skipped += a.skip_to_quality(minquality - bq)
                 aq = a.block_quality()
@@ -516,7 +516,7 @@ class IntersectionMatcher(AdditiveBiMatcher):
         skipped = 0
         aq = a.block_quality()
         bq = b.block_quality()
-        while a.is_active() and b.is_active() and aq + bq <= minquality:
+        while a.is_active() and b.is_active() and aq + bq < minquality:
             if aq < bq:
                 # If the block quality of A is less than B, skip A ahead until
                 # it can contribute at least the balance of the required min
@@ -771,7 +771,7 @@ class AndMaybeMatcher(AdditiveBiMatcher):
         skipped = 0
         aq = a.block_quality()
         bq = b.block_quality()
-        while a.is_active() and b.is_active() and aq + bq <= minquality:
+        while a.is_active() and b.is_active() and aq + bq < minquality:
             if aq < bq:
                 skipped += a.skip_to_quality(minquality - bq)
                 aq = a.block_quality()


### PR DESCRIPTION
#461 Infinite loop is caused by floating point rounding error. Illustration of my scenario:
At `binary.py:774`, condition `aq + bq <= minquality` should be `False`, but returns `True` due to FP rounding error. It happens in conjunction with `whoosh3.py:1042`, which resolves to `True` and so returns 0. The discrepancy between the two conditions caused by the rounding error conspires to keep them passing control back and forth:
```
binary:774: aq + bq is equal to minscore and aq < bq.
binary:776: 'a', please skip until your quality exceeds the difference between bq and minscore
whoosh3.py:1042: My current block_quality already exceeds minquality. No change
binary:777: Thanks, now calculate the new block quality and...
binary:774: check again if together with bq it exceeds minquality.
```
But block quality did not increase -> infinite loop.

At `binary:774`:
```
aq =  9.455230948883559
bq = 13.801099819199575
minquality = 23.25633076808313
aq + bq = 23.25633076808313
aq + bq <= minquality 
	True
aq + bq < minquality 
	False
aq+bq == minquality
	True
```
However, upon closer inspection with `Decimal`:
```
Decimal(aq) = 9.4552309488835586392951881862245500087738037109375
Decimal(bq) = 13.801099819199574625372406444512307643890380859375
Decimal(minquality) = 23.256330768083131488310755230486392974853515625
Decimal(aq) + Decimal(bq) = 23.25633076808313326466759463
Decimal(aq) + Decimal(bq) <= Decimal(minquality)
	False
```
So in fact, `aq+bq > minquality` even though Python resolves `(aq+bq == minquality)` to `True`.

My solution is to remove the `=` from the condition for all 3 Matchers where this appears:
`aq + bq < minquality`

This correctly returns `False` without using `Decimal` because the problem was a false equality. It assumes that Python would never incorrectly consider `x < y` when `Decimal(x) > Decimal(y)`. If this is possible, usage of `decimal.Decimal` should be considered for this comparison, but I preferred to avoid it if possible for now.