### PR TITLE
Resolve #484

### DIFF
--- a/src/whoosh/codec/base.py
+++ b/src/whoosh/codec/base.py
@@ -510,6 +510,12 @@ class Segment(object):
     def __repr__(self):
         return "<%s %s>" % (self.__class__.__name__, self.segment_id())
 
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.segment_id() == other.segment_id()
+
+    def __hash__(self):
+        return hash(self.segment_id())
+
     def codec(self):
         raise NotImplementedError
 

--- a/src/whoosh/reading.py
+++ b/src/whoosh/reading.py
@@ -169,6 +169,12 @@ class IndexReader(object):
 
         return None
 
+    def segments(self):
+        """Returns a list of :class:`whoosh.index.Segment` objects used by this reader.
+        """
+
+        return None
+
     def storage(self):
         """Returns the :class:`whoosh.filedb.filestore.Storage` object used by
         this reader to read its files. If the reader is not atomic,
@@ -626,6 +632,9 @@ class SegmentReader(IndexReader):
     def segment(self):
         return self._segment
 
+    def segments(self):
+        return [self.segment()]
+
     def storage(self):
         return self._storage
 
@@ -897,6 +906,9 @@ class EmptyReader(IndexReader):
     def __iter__(self):
         return iter([])
 
+    def segments(self):
+        return None
+
     def cursor(self, fieldname):
         from whoosh.codec.base import EmptyCursor
 
@@ -1006,6 +1018,9 @@ class MultiReader(IndexReader):
 
     def cursor(self, fieldname):
         return MultiCursor([r.cursor(fieldname) for r in self.readers])
+
+    def segments(self):
+        return [reader.segment() for reader in self.readers if reader.segment() is not None]
 
     def is_atomic(self):
         return False

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -1590,21 +1590,21 @@ def test_groupedby_with_terms():
         assert r.matched_terms() == set([('content', b('ipfstd1'))])
 
 
-def test_buffered_refresh():
-    from whoosh import writing
-
-    schema = fields.Schema(foo=fields.ID())
-    ix = RamStorage().create_index(schema)
-
-    with writing.BufferedWriter(ix, period=1000) as writer:
-        writer.add_document(foo='1')
-        writer.add_document(foo='2')
-
-        with writer.searcher() as searcher:
-            assert searcher.doc_count() == 2
-            assert not searcher.up_to_date()
-            searcher = searcher.refresh()
-            assert searcher.doc_count() == 2
+# def test_buffered_refresh():
+    # from whoosh import writing
+    #
+    # schema = fields.Schema(foo=fields.ID())
+    # ix = RamStorage().create_index(schema)
+    #
+    # with writing.BufferedWriter(ix, period=1000) as writer:
+    #     writer.add_document(foo='1')
+    #     writer.add_document(foo='2')
+    #
+    #     with writer.searcher() as searcher:
+    #         assert searcher.doc_count() == 2
+    #         assert not searcher.up_to_date()
+    #         searcher = searcher.refresh()
+    #         assert searcher.doc_count() == 2
 
 
 def test_score_length():

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -1590,6 +1590,23 @@ def test_groupedby_with_terms():
         assert r.matched_terms() == set([('content', b('ipfstd1'))])
 
 
+def test_buffered_refresh():
+    from whoosh import writing
+
+    schema = fields.Schema(foo=fields.ID())
+    ix = RamStorage().create_index(schema)
+
+    with writing.BufferedWriter(ix, period=1000) as writer:
+        writer.add_document(foo='1')
+        writer.add_document(foo='2')
+
+        with writer.searcher() as searcher:
+            assert searcher.doc_count() == 2
+            assert not searcher.up_to_date()
+            searcher = searcher.refresh()
+            assert searcher.doc_count() == 2
+
+
 def test_score_length():
     schema = fields.Schema(a=fields.TEXT, b=fields.TEXT)
     ix = RamStorage().create_index(schema)

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -1590,21 +1590,21 @@ def test_groupedby_with_terms():
         assert r.matched_terms() == set([('content', b('ipfstd1'))])
 
 
-# def test_buffered_refresh():
-    # from whoosh import writing
-    #
-    # schema = fields.Schema(foo=fields.ID())
-    # ix = RamStorage().create_index(schema)
-    #
-    # with writing.BufferedWriter(ix, period=1000) as writer:
-    #     writer.add_document(foo='1')
-    #     writer.add_document(foo='2')
-    #
-    #     with writer.searcher() as searcher:
-    #         assert searcher.doc_count() == 2
-    #         assert not searcher.up_to_date()
-    #         searcher = searcher.refresh()
-    #         assert searcher.doc_count() == 2
+def test_buffered_refresh():
+    from whoosh import writing
+
+    schema = fields.Schema(foo=fields.ID())
+    ix = RamStorage().create_index(schema)
+
+    with writing.BufferedWriter(ix, period=1000) as writer:
+        writer.add_document(foo=u('1'))
+        writer.add_document(foo=u('2'))
+
+        with writer.searcher() as searcher:
+            assert searcher.doc_count() == 2
+            assert not searcher.up_to_date()
+            searcher = searcher.refresh()
+            assert searcher.doc_count() == 2
 
 
 def test_score_length():


### PR DESCRIPTION
Bug resolution proposal for #484 

My assessment was that in the `refresh()` stack the memory buffer was being ignored and overridden by the file index. Was there a scenario where this even worked?

What I saw was that upon calling refresh, at the following stack point:
```
reader, index.py:553
refresh, searching.py:251
```
the statement `info = self._read_toc()` reads the index TOC from disk and loads its metadata into `info`. It passes this in the next line to `self._reader()`. At this stack point:
```
_reader, index.py:500
reader, index.py:555
refresh, searching.py:251
```
the function is supplied with `reuse=IndexReader` containing the existing memory buffer. The function is supposed to carry this over into the newly created `IndexReader`.

The remaining parameters are taken from the `info` object of the caller, describing the metadata of the disk index. The first thing it does is to check if `len(segments) == 0`. Because segments came from `info.segments`, which describes the disk index, this is `True` because nothing has been committed to disk yet, _even though there are segments in memory_. It returns an `EmptyReader`, completely ignoring the contents of the supplied memory `IndexReader` in `reuse`. This leads to an empty searcher returning from `refresh()`.

`_reader()` does check for `reuse` after this `return` statement, but it's too late. Similarly, if there is one commit before calling `refresh`, `segments` here shows the one committed segment, whereas `reuse` contains two: the committed one on disk + the uncommitted one in memory.

The fix in my view was to ~~override~~ merge the disk `segments` in `_reader()` with the memory (`reuse`) segments, if `reuse is not None`.

Proposed lines `index.py:502-505` do this. The `if` logic inside handles access to the segments across the different `IndexReader` subclasses.

Moreover, `index.py:511` in the original file didn't seem right. It creates a dictionary using generation as the key, but never uses it. Instead, at line 518 it attempts to look up the dictionary using segment id, which always failed. I changed the dictionary creation to use segment id as the key, which matches correctly during lookups.

The header changes were proposed by PyCharm. I'm still learning the code so I might be wrong, but it works well for me and the pytests succeed. Please take a close look as well and see if you agree.
