### PR TITLE
Workaround for Python issue #29097

### DIFF
--- a/tests/test_parse_plugins.py
+++ b/tests/test_parse_plugins.py
@@ -169,7 +169,7 @@ def test_daterange_empty_field():
     writer.commit()
 
     with ix.searcher() as s:
-        q = query.DateRange("test", datetime.fromtimestamp(0),
+        q = query.DateRange("test", datetime.fromtimestamp(86400),
                             datetime.today())
         r = s.search(q)
         assert len(r) == 0


### PR DESCRIPTION
Call to `datetime.fromtimestamp(0)` returns `OSError` on Windows and Python 3.6+. Suggested fix to use 86400 as the lowest parameter value.

https://bugs.python.org/issue29097