### PR TITLE
Fix 480: GtLtPlugin recurse GroupNodes

### DIFF
--- a/src/whoosh/qparser/plugins.py
+++ b/src/whoosh/qparser/plugins.py
@@ -1116,6 +1116,8 @@ class GtLtPlugin(TaggingPlugin):
                         newgroup.append(self.make_range(nextnode, node.rel))
                         # Skip the next node
                         i += 1
+            elif isinstance(node, syntax.GroupNode):
+                newgroup.append(self.do_gtlt(parser, node))
             else:
                 # If it's not a GtLtNode, add it to the filtered group
                 newgroup.append(node)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -59,6 +59,22 @@ def test_groups():
     assert repr(ns) == "<AndGroup <None:'a'>, <AndGroup <AndGroup <None:'b'>, <None:'c'>>, <None:'d'>>, <None:'e'>>"
 
 
+def test_groups_with_range():
+    p = default.QueryParser("t", None, [plugins.FieldsPlugin(),
+                                        plugins.GtLtPlugin(),
+                                        plugins.GroupPlugin(),
+                                        plugins.OperatorsPlugin(),
+                                        plugins.PhrasePlugin(),
+                                        plugins.RangePlugin(),
+                                        plugins.RegexPlugin()])
+
+    ns = p.process('a:b OR e:>=5 g:<6')
+    assert repr(ns) == "<AndGroup <OrGroup <'a':'b'>, <'e':['5' None]>>, <'g':[None '6'}>>"
+
+    ns = p.process('a:b OR (e:>=5 g:<6)')
+    assert repr(ns) == "<AndGroup <OrGroup <'a':'b'>, <AndGroup <'e':['5' None]>, <'g':[None '6'}>>>>"
+
+
 def test_fieldnames():
     p = default.QueryParser("t", None, [plugins.WhitespacePlugin(),
                                         plugins.FieldsPlugin(),


### PR DESCRIPTION
Resolve bug #480.

This happens with numeric ranges in parentheses. The root cause was an omission in `plugins.py:GtLtPlugin`. During the `filterize()` function in `qparser/default.py:329`, the nodes are run through all registered plugins in sequence. In the `GtLtPlugin (qparser/plugins.py)`, the main method `do_gtlt` converts `GtLtNode` nodes to `RangeNode` nodes but omitted to recurse down its subnodes to do the same. As a result, ranges inside a parenthesis were being ignored, leaving the ranges in their raw, unprocessed form. The nodes coming out of the `filterize()` function should never have a `GtLtNode` because they don't have a query() method. Thus the OP's scenario raises a `NotImplementedError` exception.

The solution properly recurses through the nodes and yields a fully processed query node tree.