### PR TITLE
Fix 472: Include dynamic fields in optimization

### DIFF
--- a/src/whoosh/writing.py
+++ b/src/whoosh/writing.py
@@ -684,7 +684,8 @@ class SegmentWriter(IndexWriter):
                 docmap[docnum] = self.docnum
 
             pdw.start_doc(self.docnum)
-            for fieldname in fieldnames:
+            # Set disjunction includes dynamic fields (can be different for each document)
+            for fieldname in fieldnames | set(s for s in stored if s in self.schema):
                 fieldobj = schema[fieldname]
                 length = reader.doc_field_length(docnum, fieldname)
                 pdw.add_field(fieldname, fieldobj,

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -679,6 +679,30 @@ def test_globfield_length_merge():
             assert paths == ["/a", "/b"]
 
 
+def test_glob_optimize():
+    # Issue 472: Stored dynamic field deleted after commit with optimize
+
+    schema = fields.Schema()
+    schema.add("f*", fields.STORED, glob=True)
+
+    with TempIndex(schema, "globoptimize") as ix:
+        writer = ix.writer()
+
+        # Create document with dynamic fields
+        writer.add_document(f1=1, f2=2)
+        writer.commit()
+
+        # Read back fields
+        assert list(ix.reader().all_stored_fields()) == [{'f1': 1, 'f2': 2}]
+
+        # Optimize
+        writer = ix.writer()
+        writer.commit(optimize=True)
+
+        # Read fields again
+        assert list(ix.reader().all_stored_fields()) == [{'f1': 1, 'f2': 2}]
+
+
 def test_index_decimals():
     from decimal import Decimal
 


### PR DESCRIPTION
Fix #472. When optimizing, the `OPTIMIZE` function adds a `SegmentReader` to the writer (`writing.py:115`) that it uses to build the new, optimized segment. At `writing.py:688`, `write_per_doc` collects all matching `fieldnames` from the schema, but neglects to also consider matching stored dynamic fields in the documents it reads. The modification appends all matching stored dynamic fields to the set for this loop so they can be included in the reader.

I'm not completely sure there isn't a better place for this logic, especially given the warning at the beginning of `write_per_doc` indicating the whole thing might not be implemented in the best way, but debugging led me here and all the tests pass. I recommend additional system testing on existing code that utilizes dynamic fields too.