### PR TITLE
Fix #375: Clean up writer for failed document add when exceptions wer…

### DIFF
--- a/src/whoosh/codec/whoosh3.py
+++ b/src/whoosh/codec/whoosh3.py
@@ -251,6 +251,10 @@ class W3PerDocWriter(base.PerDocWriterWithColumns):
             sf.clear()
         self._indoc = False
 
+    def cancel_doc(self):
+        self._doccount -= 1
+        self._indoc = False
+
     def _column_filename(self, fieldname):
         return W3Codec.column_filename(self._segment, fieldname)
 

--- a/src/whoosh/writing.py
+++ b/src/whoosh/writing.py
@@ -735,58 +735,62 @@ class SegmentWriter(IndexWriter):
         self._check_fields(schema, fieldnames)
 
         perdocwriter.start_doc(docnum)
-        for fieldname in fieldnames:
-            value = fields.get(fieldname)
-            if value is None:
-                continue
-            field = schema[fieldname]
+        try:
+            for fieldname in fieldnames:
+                value = fields.get(fieldname)
+                if value is None:
+                    continue
+                field = schema[fieldname]
 
-            length = 0
-            if field.indexed:
-                # TODO: Method for adding progressive field values, ie
-                # setting start_pos/start_char?
-                fieldboost = self._field_boost(fields, fieldname, docboost)
-                # Ask the field to return a list of (text, weight, vbytes)
-                # tuples
-                items = field.index(value)
-                # Only store the length if the field is marked scorable
-                scorable = field.scorable
-                # Add the terms to the pool
-                for tbytes, freq, weight, vbytes in items:
-                    weight *= fieldboost
-                    if scorable:
-                        length += freq
-                    add_post((fieldname, tbytes, docnum, weight, vbytes))
+                length = 0
+                if field.indexed:
+                    # TODO: Method for adding progressive field values, ie
+                    # setting start_pos/start_char?
+                    fieldboost = self._field_boost(fields, fieldname, docboost)
+                    # Ask the field to return a list of (text, weight, vbytes)
+                    # tuples
+                    items = field.index(value)
+                    # Only store the length if the field is marked scorable
+                    scorable = field.scorable
+                    # Add the terms to the pool
+                    for tbytes, freq, weight, vbytes in items:
+                        weight *= fieldboost
+                        if scorable:
+                            length += freq
+                        add_post((fieldname, tbytes, docnum, weight, vbytes))
 
-            if field.separate_spelling():
-                spellfield = field.spelling_fieldname(fieldname)
-                for word in field.spellable_words(value):
-                    word = utf8encode(word)[0]
-                    # item = (fieldname, tbytes, docnum, weight, vbytes)
-                    add_post((spellfield, word, 0, 1, vbytes))
+                if field.separate_spelling():
+                    spellfield = field.spelling_fieldname(fieldname)
+                    for word in field.spellable_words(value):
+                        word = utf8encode(word)[0]
+                        # item = (fieldname, tbytes, docnum, weight, vbytes)
+                        add_post((spellfield, word, 0, 1, vbytes))
 
-            vformat = field.vector
-            if vformat:
-                analyzer = field.analyzer
-                # Call the format's word_values method to get posting values
-                vitems = vformat.word_values(value, analyzer, mode="index")
-                # Remove unused frequency field from the tuple
-                vitems = sorted((text, weight, vbytes)
-                                for text, _, weight, vbytes in vitems)
-                perdocwriter.add_vector_items(fieldname, field, vitems)
+                vformat = field.vector
+                if vformat:
+                    analyzer = field.analyzer
+                    # Call the format's word_values method to get posting values
+                    vitems = vformat.word_values(value, analyzer, mode="index")
+                    # Remove unused frequency field from the tuple
+                    vitems = sorted((text, weight, vbytes)
+                                    for text, _, weight, vbytes in vitems)
+                    perdocwriter.add_vector_items(fieldname, field, vitems)
 
-            # Allow a custom value for stored field/column
-            customval = fields.get("_stored_%s" % fieldname, value)
+                # Allow a custom value for stored field/column
+                customval = fields.get("_stored_%s" % fieldname, value)
 
-            # Add the stored value and length for this field to the per-
-            # document writer
-            sv = customval if field.stored else None
-            perdocwriter.add_field(fieldname, field, sv, length)
+                # Add the stored value and length for this field to the per-
+                # document writer
+                sv = customval if field.stored else None
+                perdocwriter.add_field(fieldname, field, sv, length)
 
-            column = field.column_type
-            if column and customval is not None:
-                cv = field.to_column_value(customval)
-                perdocwriter.add_column_value(fieldname, column, cv)
+                column = field.column_type
+                if column and customval is not None:
+                    cv = field.to_column_value(customval)
+                    perdocwriter.add_column_value(fieldname, column, cv)
+        except Exception as ex:
+            perdocwriter.cancel_doc()
+            raise ex
 
         perdocwriter.finish_doc()
         self._added = True


### PR DESCRIPTION
Fix for #375 : "Called start_doc when already in a doc"

I encountered this problem when adding to Whoosh from inside a pandas apply() function. Pandas does a first pass that absorbs exceptions.

This has also been observed by others, such as: https://github.com/django-haystack/django-haystack/issues/952

Reproduction:
```
schema = fields.Schema(id=fields.ID())
st = RamStorage()
ix = st.create_index(schema)

with ix.writer() as w:
    try:
        # Integer value is invalid, but absorbed exception causes silent failure
        w.add_document(id=1)
    except:
        pass

    w.add_document(id=2)
```

1. Add a document that will fail (such as with an integer value instead of the expected Unicode or sequence)
2. Absorb the exception while doing so
3. Try to add another document that will fail

Expected Result: 
An appropriate exception for the problem with document 2:
`Exception: 2 is not unicode or sequence`
Actual Result: 
`Exception: Called start_doc when already in a doc`

When the first document fails, the exception is not allowed to bubble up by the repro code. However, this leaves the PerDocumentWriter in an unfinished state (`_indoc==True`). When the second document add is attempted, the writer finds itself in an invalid state and throws the `Called start_doc when already in a doc` exception, which is cryptic and meaningless to the user.

The fix ensures that the PerDocumentWriter is properly cleaned up in the event of a failure by implementing its own try/except block. This allows the correct exception to bubble up for the second problem.