### PR TITLE
Highlight longest overlapping token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.7"
 
 install:
-  - pip install pytest nose codecov coverage cached-property
+  - pip install pytest nose codecov coverage cached-property jieba
 
 script:
   - nosetests  --with-coverage

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!python
 
-import os.path, sys
+import os.path
+import sys
+
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -20,7 +22,7 @@ class PyTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import pytest
         pytest.main(self.test_args)
 
@@ -44,18 +46,18 @@ if __name__ == "__main__":
 
         zip_safe=True,
         install_requires=['cached-property'],
-        tests_require=['pytest'],
+        tests_require=['pytest', 'jieba'],
         cmdclass={'test': PyTest},
 
         classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Natural Language :: English",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.5",
-        "Programming Language :: Python :: 3",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Text Processing :: Indexing",
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: BSD License",
+            "Natural Language :: English",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python :: 2.5",
+            "Programming Language :: Python :: 3",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+            "Topic :: Text Processing :: Indexing",
         ],
     )

--- a/src/whoosh/highlight.py
+++ b/src/whoosh/highlight.py
@@ -131,8 +131,8 @@ class Fragment(object):
                 self.matched_terms.add(t.text)
 
     def __repr__(self):
-        return "<Fragment %d:%d %d>" % (self.startchar, self.endchar,
-                                        len(self.matches))
+        return "<Fragment %d:%d has %d matches>" % (self.startchar, self.endchar,
+                                                    len(self.matches))
 
     def __len__(self):
         return self.endchar - self.startchar
@@ -695,7 +695,12 @@ class Formatter(object):
         index = fragment.startchar
         text = fragment.text
 
-        for t in fragment.matches:
+        # For overlapping tokens (such as in Chinese), sort by position,
+        # then by inverse of length.
+        # Because the formatter is sequential, it will only pick the first
+        # token for a given position to highlight. This makes sure it picks
+        # the longest overlapping token.
+        for t in sorted(fragment.matches, key=lambda token: (token.startchar, -(token.endchar - token.startchar))):
             if t.startchar is None:
                 continue
             if t.startchar < index:

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -341,7 +341,7 @@ def test_overlapping_tokens():
 
     terms = [token.text for token in analyzer(query_string)]
 
-    assert terms == ['马克', '马克思']
+    assert terms == [u('马克'), u('马克思')]
 
     output = highlight.highlight(
         text,

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -341,8 +341,6 @@ def test_overlapping_tokens():
 
     terms = [token.text for token in analyzer(query_string)]
 
-    assert terms == [u('马克'), u('马克思')]
-
     output = highlight.highlight(
         text,
         terms,

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -334,8 +334,8 @@ def test_whole_noterms():
 
 
 def test_overlapping_tokens():
-    query_string = "马克思"
-    text = "两次历史性飞跃与马克思主义中国化"
+    query_string = u("马克思")
+    text = u("两次历史性飞跃与马克思主义中国化")
     analyzer = ChineseAnalyzer()
     formatter = highlight.HtmlFormatter()
 

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -334,8 +334,8 @@ def test_whole_noterms():
 
 
 def test_overlapping_tokens():
-    query_string = u("马克思")
-    text = u("两次历史性飞跃与马克思主义中国化")
+    query_string = u'马克思'
+    text = u'两次历史性飞跃与马克思主义中国化'
     analyzer = ChineseAnalyzer()
     formatter = highlight.HtmlFormatter()
 
@@ -349,6 +349,6 @@ def test_overlapping_tokens():
         formatter
     )
 
-    assert output == u('两次历史性飞跃与<strong class="match term0">马克思</strong>主义中国化'), \
-        'The longest overlapping token 马克思 was not selected by the highlighter' + ' : ' + output
+    assert output == u'两次历史性飞跃与<strong class="match term0">马克思</strong>主义中国化', \
+        u'The longest overlapping token 马克思 was not selected by the highlighter'
     # as opposed to '两次历史性飞跃与<strong class="match term0">马克</strong>思主义中国化'

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -349,6 +349,6 @@ def test_overlapping_tokens():
         formatter
     )
 
-    assert output == '两次历史性飞跃与<strong class="match term0">马克思</strong>主义中国化', \
+    assert output == u('两次历史性飞跃与<strong class="match term0">马克思</strong>主义中国化'), \
         'The longest overlapping token 马克思 was not selected by the highlighter'
     # as opposed to '两次历史性飞跃与<strong class="match term0">马克</strong>思主义中国化'

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -2,8 +2,8 @@
 
 from __future__ import with_statement
 
-from jieba.analyse import ChineseAnalyzer
 import pytest
+from jieba.analyse import ChineseAnalyzer
 
 from whoosh import analysis, highlight, fields, qparser, query
 from whoosh.compat import u
@@ -350,5 +350,5 @@ def test_overlapping_tokens():
     )
 
     assert output == u('两次历史性飞跃与<strong class="match term0">马克思</strong>主义中国化'), \
-        'The longest overlapping token 马克思 was not selected by the highlighter'
+        'The longest overlapping token 马克思 was not selected by the highlighter' + ' : ' + output
     # as opposed to '两次历史性飞跃与<strong class="match term0">马克</strong>思主义中国化'


### PR DESCRIPTION
The highlighter Formatter was not appropriately handling overlapping tokens. In Chinese, words can be subsets of other words, so unlike in English, multiple tokens can overlap. For example, in "中国化", both 中国 and 中国化 are valid tokens, each with a different meaning. Because the Formatter was failing to account for this scenario, it was picking the first matching token to highlight and then moving to the next character, causing it to skip the second token. Furthermore, because the shorter token had been detected before the longer one, it was always the shorter one that got highlighted.

However, the longest token among overlapping ones is always the most accurate, because it is the most specific. The proposed fix in this PR therefore sorts by match position first, and then by descending token length before formatting, ensuring the longest overlapping token is the one highlighted.

Fixed #532.