### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Learning more
 
 * Join the Whoosh mailing list at http://groups.google.com/group/whoosh
 
-* File bug reports and view the Whoosh wiki at
-  http://bitbucket.org/mchaput/whoosh/
+* File bug reports at https://github.com/whoosh-community/whoosh/
 
 Getting the source
 ==================


### PR DESCRIPTION
Updated README.md to point to the whoosh-community github page instead of the old bitbucket space.